### PR TITLE
Add cda restreint

### DIFF
--- a/input/pagecontent/profils-messages.md
+++ b/input/pagecontent/profils-messages.md
@@ -3238,6 +3238,13 @@ Cet OBX permet d'informer l'acteur GESTIONNAIRE que le document doit
   </tbody>
 </table>
 
+<blockquote class="stu-note">
+    <p>
+    <b>Point d’attention : Un document ayant un niveau renforcé de confidentialité (restreint ou très restreint) ne devrait pas être mis en partage. 
+    </p>
+</blockquote>
+
+
 ###### Echange MSSanté Professionnel de Santé/Organisation/BAL applicative
 
 Cet OBX permet d'informer l'acteur GESTIONNAIRE que le document doit

--- a/input/pagecontent/profils-messages.md
+++ b/input/pagecontent/profils-messages.md
@@ -3240,7 +3240,7 @@ Cet OBX permet d'informer l'acteur GESTIONNAIRE que le document doit
 
 <blockquote class="stu-note">
     <p>
-    <b>Point d’attention : Un document ayant un niveau renforcé de confidentialité (restreint ou très restreint) ne devrait pas être mis en partage. 
+    <b>Point d’attention : </b>Un document ayant un niveau renforcé de confidentialité (restreint ou très restreint) ne devrait pas être mis en partage. 
     </p>
 </blockquote>
 


### PR DESCRIPTION
## Description des changements

Ajout de l'information suivante pour le DMP : 
Un document ayant un niveau renforcé de confidentialité (restreint ou très restreint), devrait être remis en mains propres, ou envoyé sous pli scellé ou par message direct à son destinataire. Il ne devrait pas être mis en partage.


## Preview

[https://ansforge.github.io/IG-fhir-[nom repo]/[ajouter_nom_de_la_branche]/ig](https://ansforge.github.io/IG-hl7v2-volet-transmission-document-cda-r2/add-cda-restreint/ig/volume2.html#alimentation-dmp)

##Issue 
#15 


